### PR TITLE
DayPlan-2: Eslint improvements and fixes

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -5,9 +5,17 @@ import reactRefresh from 'eslint-plugin-react-refresh'
 import tseslint from 'typescript-eslint'
 import reactX from 'eslint-plugin-react-x'
 import reactDom from 'eslint-plugin-react-dom'
+import {readFileSync} from 'fs'
 
 export default tseslint.config(
-    {ignores: ['dist']},
+    {
+        ignores: [
+            'dist',
+            ...readFileSync('.gitignore', 'utf8')
+                .split('\n')
+                .filter((line) => line && !line.startsWith('#')),
+        ],
+    },
     {
         extends: [js.configs.recommended, ...tseslint.configs.strictTypeChecked],
         files: ['**/*.{ts,tsx}'],
@@ -45,6 +53,7 @@ export default tseslint.config(
                 },
             ],
             eqeqeq: ['error'],
+            '@typescript-eslint/consistent-type-imports': 'error',
         },
     },
 )


### PR DESCRIPTION
Changes:

- Added a nice to have rule for eslint that I really like, enforcing imports used only as type to be imported as type. This avoids executing files unnecessarily.
- Fixes a couple eslint warn/error about useEffect dep and type import
- Automatically ignore .gitignore in eslint config

Not changing version for this one. This has no effect on anything, I would merge it to app-dev but I won't create that env yet just because I don't want a second deployment on aws unnecessarily for now.

This is also testing Amplify's auto branch detection feature. Although I don't have a Jira or similar for this project, I'm treating `DayPlan-` as my project's issue key. Any branch with DayPlan- is automatically deployed to amplify, and protected by a secret password. This would be used by devs to test their changes deployed before approving and merging a PR. The branch name can't be too long or it apparently exceeds some limit where the DNS doesn't work. Same goes for branches starting with `app-`, these will be my lower envs. PRs don't generate an auto deployed version because anyone could open an MR to this repository.